### PR TITLE
Support for RadioHead's RHReliableDatagram protocol

### DIFF
--- a/RH_Serial.cpp
+++ b/RH_Serial.cpp
@@ -12,6 +12,7 @@ RH_Serial::RH_Serial(HardwareSerial& serial)
     _serial(serial),
     _rxState(RxStateInitialising)
 {
+	clearRxBuf();
 }
 
 HardwareSerial& RH_Serial::serial()
@@ -60,7 +61,7 @@ bool RH_Serial::waitAvailableTimeout(uint16_t timeout)
     }
     return false;
 #else
-    RHGenericDriver::waitAvailableTimeout(timeout);
+    return RHGenericDriver::waitAvailableTimeout(timeout);
 #endif
 }
 

--- a/RHutil/RasPi.cpp
+++ b/RHutil/RasPi.cpp
@@ -173,4 +173,9 @@ size_t SerialSimulator::println(unsigned char ch, int base)
   printf("\n");
 }
 
+void resetTimerValue() {
+    gettimeofday(&RHStartTime, NULL);
+}
+
+
 #endif

--- a/RHutil/RasPi.h
+++ b/RHutil/RasPi.h
@@ -72,4 +72,6 @@ void delay (unsigned long delay);
 
 long random(long min, long max);
 
+extern void resetTimerValue();
+
 #endif


### PR DESCRIPTION
This PR is a sub-module modification for the primary changes made in linux-mqtt-sn-gateway.

The primary purpose of this PR is to add support for using RadioHead's serial protocol on a serial port via the new RHSerialSocket class. To support this, RHReliableDatagramSocket and RHDatagramSocket were also created. Unless you pre-existing code that requires RHDatagram as your manager, RHReliableDatagramSocket is preffered, as it can talk to both protocols by simply switching on/off "reliable" mode.

The Transmission protocol identifier RH_SERIAL was added to the list identifiers that can be passed to CMake.

This PR was made for and tested on my primary use case: an MQTT-SN gateway on a Raspberry Pi. As part of this, the Gateway code made more robust and fault tolerant. Terminating a thread due to an error condition now throws the catchable exception LinuxSystem::ThreadTerminated. In response to that, the gateway now shuts down gracefully when sockets are lost or endpoints are not set up correctly. Finally, I added some logger messages to the early begin() and init() procedures to help diagnose setup errors, and I cleaned up a compiler warnings in the core.